### PR TITLE
[MCC-187333] Fix DbInfoHandler and version up to 1.3.0

### DIFF
--- a/Mct.RaveCommon.UnitTests/DBInfoHandlerTests.cs
+++ b/Mct.RaveCommon.UnitTests/DBInfoHandlerTests.cs
@@ -1,40 +1,139 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.Data;
+using System.Data.SqlClient;
+using System.Dynamic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Ploeh.AutoFixture;
 using Ploeh.AutoFixture.AutoRhinoMock;
+using Rhino.Mocks;
 
 namespace Medidata.Cloud.Thermometer.RaveCommon.UnitTests
 {
-	[TestClass]
-	public class DBInfoHandlerTests
-	{
-		private IFixture _fixture;
+    [TestClass]
+    public class DbInfoHandlerTests
+    {
+        private IFixture _fixture;
 
-		[TestInitialize]
-		public void Init()
-		{
-			_fixture = new Fixture().Customize(new AutoRhinoMockCustomization());
-		}
-		[TestMethod]
-		public void HandlerShouldParseDataSettingsSection()
-		{
-			//Arrange
-			var question = _fixture.Create<IThermometerQuestion>();
+        [TestInitialize]
+        public void Init()
+        {
+            _fixture = new Fixture().Customize(new AutoRhinoMockCustomization());
+        }
 
-			//Act
-			var sut = new DBInfoHandler();
-			dynamic answer = sut.Handler(question);
-			
-			//Assert
-			Assert.AreEqual(10, answer.CachingTimeOut);
-			Assert.AreEqual("RaveDev", answer.DefaultHint);
-			Assert.AreEqual(3, answer.ConnectionSettings.Count);
-			Assert.AreEqual("RaveDev", answer.ConnectionSettings[0].DataSourceHint);
-			Assert.AreEqual("RaveDev_Reporter", answer.ConnectionSettings[1].DataSourceHint);
-			Assert.AreEqual("RaveDev_Migration", answer.ConnectionSettings[2].DataSourceHint);
-		}
-	}
+        [TestMethod]
+        public void CreateConnection_ReturnsSqlConnection()
+        {
+            var connectionString = "Server=WIN81;Database=RaveDev;uid=RaveDev;pwd=password*8";
+            var sut = new DbInfoHandler();
+
+            var result = sut.CreateConnection(connectionString);
+
+            Assert.IsInstanceOfType(result, typeof (SqlConnection));
+        }
+
+        [TestMethod]
+        public void GetConnectionState_ReturnsConnectionState()
+        {
+            var connectionString = _fixture.Create<string>();
+            var state = _fixture.Create<ConnectionState>();
+            var connection = _fixture.Create<IDbConnection>();
+            connection.Stub(x => x.State).Return(state);
+
+            var sut = MockRepository.GeneratePartialMock<DbInfoHandler>();
+            sut.Stub(x => x.CreateConnection(connectionString)).Return(connection);
+
+            var result = sut.GetConnectionState(connectionString);
+
+            Assert.AreEqual(state, result);
+        }
+
+        [TestMethod]
+        public void GetConnectionState_ReturnsException()
+        {
+            var connectionString = _fixture.Create<string>();
+            var exception = _fixture.Create<Exception>();
+            var connection = _fixture.Create<IDbConnection>();
+            connection.Stub(x => x.Open()).Throw(exception);
+
+            var sut = MockRepository.GeneratePartialMock<DbInfoHandler>();
+            sut.Stub(x => x.CreateConnection(connectionString)).Return(connection);
+
+            var result = sut.GetConnectionState(connectionString);
+
+            Assert.AreEqual(exception, result);
+        }
+
+        [TestMethod]
+        public void ConvertConnectionStringToObject_HidesUserIDAndPassword()
+        {
+            var serverName = _fixture.Create<string>();
+            var dbname = _fixture.Create<string>();
+            var userid = _fixture.Create<string>();
+            var password = _fixture.Create<string>();
+            var connectionString = string.Format("Server={0};Database={1};uid={2};pwd={3}", serverName, dbname, userid,
+                password);
+            var sut = new DbInfoHandler();
+
+            dynamic result = sut.ConvertConnectionStringToObject(connectionString);
+            IDictionary<string, object> dic = result;
+
+            Assert.AreEqual(serverName, dic["Data Source"]);
+            Assert.AreEqual(dbname, dic["Initial Catalog"]);
+            Assert.IsFalse(dic.ContainsKey("UserID"));
+            Assert.IsFalse(dic.ContainsKey("Password"));
+        }
+
+        [TestMethod]
+        public void ConvertToExpendoObject_ReturnsSelfIfAlreadyIsExpendo()
+        {
+            var expected = _fixture.Create<ExpandoObject>();
+            var sut = new DbInfoHandler();
+
+            var result = sut.ConvertToExpendoObject(expected);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestMethod]
+        public void ConvertToExpendoObject_ConvertsObjectToExpendo()
+        {
+            var value = _fixture.Create<string>();
+            var expected = new {x = value};
+            var sut = new DbInfoHandler();
+
+            dynamic result = sut.ConvertToExpendoObject(expected);
+
+            Assert.AreEqual(expected.x, result.x);
+        }
+
+        [TestMethod]
+        public void HandleQuestion_DataSettingsHasNoConnectionSettings()
+        {
+            var question = _fixture.Create<IThermometerQuestion>();
+            var sut = MockRepository.GeneratePartialMock<DbInfoHandler>();
+
+            var raveDataSettingsObject = _fixture.Create<object>();
+            sut.Stub(x => x.GetRaveDataSettingsSectionObject()).Return(raveDataSettingsObject);
+
+            dynamic connectionSetting1 = new ExpandoObject();
+            connectionSetting1.ConnectionString = _fixture.Create<string>();
+            dynamic connectionSetting2 = new ExpandoObject();
+            connectionSetting2.ConnectionString = _fixture.Create<string>();
+
+            dynamic expendo = _fixture.Create<ExpandoObject>();
+            expendo.ConnectionSettings = new[] {connectionSetting1, connectionSetting2};
+            sut.Stub(x => x.ConvertToExpendoObject(raveDataSettingsObject)).Return(expendo);
+
+            var connectionState1 = _fixture.Create<ConnectionState>();
+            sut.Stub(x => x.GetConnectionState(null)).IgnoreArguments().Return(connectionState1);
+
+            var connectionObject1 = _fixture.Create<ExpandoObject>();
+            sut.Stub(x => x.ConvertConnectionStringToObject(null)).IgnoreArguments().Return(connectionObject1);
+
+            dynamic result = sut.Handler(question);
+
+            Assert.AreEqual(expendo.ConnectionSettings.Length, result.ConnectionSettings.Length);
+        }
+    }
 }

--- a/Mct.RaveCommon.UnitTests/Medidata.Cloud.Thermometer.RaveCommon.UnitTests.csproj
+++ b/Mct.RaveCommon.UnitTests/Medidata.Cloud.Thermometer.RaveCommon.UnitTests.csproj
@@ -86,6 +86,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Data" />
     <Reference Include="System.XML" />
   </ItemGroup>
   <Choose>
@@ -102,7 +103,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="ComponentInfoHandlerTests.cs" />
-    <Compile Include="DBInfoHandlerTests.cs" />
+    <Compile Include="DbInfoHandlerTests.cs" />
     <Compile Include="MockHelpers\DatabaseSettingsStub.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="AssemblyInfoHandlerTests.cs" />

--- a/Mct.RaveCommon.UnitTests/Medidata.Cloud.Thermometer.RaveCommon.UnitTests.csproj
+++ b/Mct.RaveCommon.UnitTests/Medidata.Cloud.Thermometer.RaveCommon.UnitTests.csproj
@@ -40,8 +40,8 @@
       <HintPath>..\packages\Medidata.Cloud.StateBroker.0.1.0\lib\net40\Medidata.Cloud.StateBroker.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Medidata.Cloud.Thermometer, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Medidata.Cloud.Thermometer.1.5.0\lib\net40\Medidata.Cloud.Thermometer.dll</HintPath>
+    <Reference Include="Medidata.Cloud.Thermometer, Version=1.5.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Medidata.Cloud.Thermometer.1.5.1\lib\net40\Medidata.Cloud.Thermometer.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />

--- a/Mct.RaveCommon.UnitTests/Medidata.Cloud.Thermometer.RaveCommon.UnitTests.csproj
+++ b/Mct.RaveCommon.UnitTests/Medidata.Cloud.Thermometer.RaveCommon.UnitTests.csproj
@@ -45,28 +45,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Owin, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.2.1.0\lib\net40\Microsoft.Owin.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Owin.Host.HttpListener, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.Host.HttpListener.2.1.0\lib\net40\Microsoft.Owin.Host.HttpListener.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Owin.Hosting, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.Hosting.2.1.0\lib\net40\Microsoft.Owin.Hosting.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Moq, Version=4.1.1308.2120, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.1.1308.2120\lib\net40\Moq.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
-      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Ploeh.AutoFixture, Version=3.34.1.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">

--- a/Mct.RaveCommon.UnitTests/packages.config
+++ b/Mct.RaveCommon.UnitTests/packages.config
@@ -5,7 +5,7 @@
   <package id="AutoFixture.AutoMoq" version="3.34.1" targetFramework="net40" />
   <package id="AutoFixture.AutoRhinoMocks" version="3.33.0" targetFramework="net40" />
   <package id="Medidata.Cloud.StateBroker" version="0.1.0" targetFramework="net40" />
-  <package id="Medidata.Cloud.Thermometer" version="1.5.0" targetFramework="net40" />
+  <package id="Medidata.Cloud.Thermometer" version="1.5.1" targetFramework="net40" />
   <package id="Microsoft.Owin" version="2.1.0" targetFramework="net40" />
   <package id="Microsoft.Owin.Host.HttpListener" version="2.1.0" targetFramework="net40" />
   <package id="Microsoft.Owin.Hosting" version="2.1.0" targetFramework="net40" />

--- a/Mct.RaveCommon/Medidata.Cloud.Thermometer.RaveCommon.csproj
+++ b/Mct.RaveCommon/Medidata.Cloud.Thermometer.RaveCommon.csproj
@@ -40,31 +40,14 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Owin, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.2.1.0\lib\net40\Microsoft.Owin.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Owin.Host.HttpListener, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.Host.HttpListener.2.1.0\lib\net40\Microsoft.Owin.Host.HttpListener.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Owin.Hosting, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.Hosting.2.1.0\lib\net40\Microsoft.Owin.Hosting.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
-      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
-    <Reference Include="System.XML" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfoHandler.cs" />

--- a/Mct.RaveCommon/Medidata.Cloud.Thermometer.RaveCommon.csproj
+++ b/Mct.RaveCommon/Medidata.Cloud.Thermometer.RaveCommon.csproj
@@ -39,6 +39,7 @@
       <HintPath>..\packages\Medidata.Cloud.Thermometer.1.5.0\lib\net40\Medidata.Cloud.Thermometer.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Owin, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Owin.2.1.0\lib\net40\Microsoft.Owin.dll</HintPath>
       <Private>True</Private>
@@ -68,7 +69,7 @@
   <ItemGroup>
     <Compile Include="AssemblyInfoHandler.cs" />
     <Compile Include="ComponentInfoHandler.cs" />
-    <Compile Include="DBInfoHandler.cs" />
+    <Compile Include="DbInfoHandler.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StateServiceBaseHandler.cs" />
   </ItemGroup>

--- a/Mct.RaveCommon/Medidata.Cloud.Thermometer.RaveCommon.csproj
+++ b/Mct.RaveCommon/Medidata.Cloud.Thermometer.RaveCommon.csproj
@@ -35,8 +35,8 @@
       <HintPath>..\packages\Medidata.Cloud.StateBroker.0.1.0\lib\net40\Medidata.Cloud.StateBroker.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Medidata.Cloud.Thermometer, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Medidata.Cloud.Thermometer.1.5.0\lib\net40\Medidata.Cloud.Thermometer.dll</HintPath>
+    <Reference Include="Medidata.Cloud.Thermometer, Version=1.5.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Medidata.Cloud.Thermometer.1.5.1\lib\net40\Medidata.Cloud.Thermometer.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />

--- a/Mct.RaveCommon/Medidata.Cloud.Thermometer.RaveCommon.nuspec
+++ b/Mct.RaveCommon/Medidata.Cloud.Thermometer.RaveCommon.nuspec
@@ -2,18 +2,18 @@
 <package>
   <metadata>
     <id>Medidata.Cloud.Thermometer.RaveCommon</id>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
     <title>Medidata.Cloud.Thermometer.RaveCommon</title>
     <authors>jshao@mdsol.com,echen@mdsol.com,chuang@mdsol.com</authors>
     <owners>jshao@mdsol.com,echen@mdsol.com,chuang@mdsol.com</owners>
     <projectUrl>https://github.com/junshao/Medidata.Cloud.Thermometer.RaveCommon</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Common library for Rave to use Thermometer</description>
-    <releaseNotes>Update dependency packages and move out ExpendoStateService</releaseNotes>
+    <releaseNotes>Add DbInfoHandler</releaseNotes>
     <copyright>Copyright 2015</copyright>
     <tags>Thermometer Rave</tags>
     <dependencies>
-      <dependency id="Medidata.Cloud.Thermometer" version="1.5.0" />
+      <dependency id="Medidata.Cloud.Thermometer" version="1.5.1" />
       <dependency id="Medidata.Cloud.StateBroker" version="0.1.0" />
     </dependencies>
   </metadata>

--- a/Mct.RaveCommon/Properties/AssemblyInfo.cs
+++ b/Mct.RaveCommon/Properties/AssemblyInfo.cs
@@ -38,5 +38,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyVersion("1.3.0.0")]
+[assembly: AssemblyFileVersion("1.3.0.0")]

--- a/Mct.RaveCommon/packages.config
+++ b/Mct.RaveCommon/packages.config
@@ -3,7 +3,7 @@
 <packages>
   <package id="CreateNewNuGetPackageFromProjectAfterEachBuild" version="1.8.8" targetFramework="net40" developmentDependency="true" />
   <package id="Medidata.Cloud.StateBroker" version="0.1.0" targetFramework="net40" />
-  <package id="Medidata.Cloud.Thermometer" version="1.5.0" targetFramework="net40" />
+  <package id="Medidata.Cloud.Thermometer" version="1.5.1" targetFramework="net40" />
   <package id="Microsoft.Owin" version="2.1.0" targetFramework="net40" />
   <package id="Microsoft.Owin.Host.HttpListener" version="2.1.0" targetFramework="net40" />
   <package id="Microsoft.Owin.Hosting" version="2.1.0" targetFramework="net40" />


### PR DESCRIPTION
### Main changes
- Fixed `DbInfoHandler` due to `ConfigurationManager.OpenExeConfiguration` doesn't work for web application. Use `ConfigurationManager.GetSection` instead.
- Added unit tests for `DbInfoHandler` to retain 100% code coverage.
    ![image](https://cloud.githubusercontent.com/assets/1455905/10009017/836a7542-60a4-11e5-96e4-12ab41523325.png)
- Use Thermometer 1.5.1.
- Reference clean up.
- Version up to 1.3.0.

@art2003 @chenghuang-mdsol @vcapers-mdsol Please review and merge if OK. Thanks.