### PR TITLE
[MCC-170850] Add RouteInfoHandler and its unit tests

### DIFF
--- a/Mct.RaveCommon.UnitTests/Medidata.Cloud.Thermometer.RaveCommon.UnitTests.csproj
+++ b/Mct.RaveCommon.UnitTests/Medidata.Cloud.Thermometer.RaveCommon.UnitTests.csproj
@@ -82,6 +82,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Web" />
     <Reference Include="System.XML" />
   </ItemGroup>
   <Choose>
@@ -103,6 +104,7 @@
     <Compile Include="DynamicExtensionsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="AssemblyInfoHandlerTests.cs" />
+    <Compile Include="RouteInfoHandlerTests.cs" />
     <Compile Include="StateServiceBaseHandlerTests.cs" />
     <Compile Include="ThermometerConditionalStarterTests.cs" />
   </ItemGroup>

--- a/Mct.RaveCommon.UnitTests/RouteInfoHandlerTests.cs
+++ b/Mct.RaveCommon.UnitTests/RouteInfoHandlerTests.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Web.Routing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Ploeh.AutoFixture;
+using Ploeh.AutoFixture.AutoRhinoMock;
+
+namespace Medidata.Cloud.Thermometer.RaveCommon.UnitTests
+{
+    [TestClass]
+    public class RouteInfoHandlerTests
+    {
+        private IFixture _fixture;
+        private IThermometerQuestion _question;
+        private RouteInfoHandler _sut;
+
+        [TestInitialize]
+        public void Init()
+        {
+            _fixture = new Fixture().Customize(new AutoRhinoMockCustomization());
+            _question = _fixture.Create<IThermometerQuestion>();
+            _sut = new RouteInfoHandler();
+        }
+
+        [TestMethod]
+        public void HandleQuestion_ReturnsRouteUrls()
+        {
+            // Arrange
+            var routes = _fixture.CreateMany<Route>().ToList();
+            foreach (var route in routes)
+            {
+                route.Url = _fixture.Create<string>();
+                RouteTable.Routes.Add(route);
+            }
+
+            // Act
+            var result = _sut.Handler(_question) as IEnumerable<object>;
+
+            // Assert
+            Assert.IsNotNull(result);
+            CollectionAssert.AreEquivalent(routes.Select(x => x.Url).ToArray(), result.ToArray());
+        }
+    }
+}

--- a/Mct.RaveCommon/Medidata.Cloud.Thermometer.RaveCommon.csproj
+++ b/Mct.RaveCommon/Medidata.Cloud.Thermometer.RaveCommon.csproj
@@ -59,6 +59,7 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
@@ -68,6 +69,7 @@
     <Compile Include="DbInfoHandler.cs" />
     <Compile Include="DynamicExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RouteInfoHandler.cs" />
     <Compile Include="StateServiceBaseHandler.cs" />
     <Compile Include="ThermometerConditionalStarter.cs" />
   </ItemGroup>

--- a/Mct.RaveCommon/RouteInfoHandler.cs
+++ b/Mct.RaveCommon/RouteInfoHandler.cs
@@ -1,0 +1,13 @@
+﻿using System.Linq;
+using System.Web.Routing;
+
+namespace Medidata.Cloud.Thermometer.RaveCommon
+{
+    public class RouteInfoHandler : ThermometerBaseHandler
+    {
+        protected override object HandleQuestion(IThermometerQuestion question)
+        {
+            return RouteTable.Routes.OfType<Route>().Select(x => x.Url);
+        }
+    }
+}


### PR DESCRIPTION
`$web`, `$rws`, and `$reporting` have this identical handler in each codebase. Move it to RaveCommon to get rid of duplication.

@echen-mdsol Please review and merge if OK. I think we can increment the version later, after you improved the `ComponentInfoHandler`.